### PR TITLE
Fix patch on _run_*_callbacks

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -1,7 +1,7 @@
 require "ar_transaction_changes/version"
 
 module ArTransactionChanges
-  if (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 2) || ActiveRecord::VERSION::MAJOR > 4
+  if Class.new { include ActiveSupport::Callbacks }.private_method_defined?(:_run_callbacks)
     def _run_create_callbacks
       ret = super
       store_transaction_changed_attributes if ret != false


### PR DESCRIPTION
Rails 4.2.3+ had reverted the commit that changed the private callbacks
API, see
https://github.com/rails/rails/commit/fe664e8ce97b5f7a1e1d95dd4df0fbdba42c7f2b.
Thus, we cannot rely on the Rails version, as 4.2.4 was not released
yet. I changed the check to check against a private method that
existed/dont before and after the patch.
Such a hack =/ , but unfortunately we are dealing with internal apis
that can change at any time.

review @dylanahsmith @rafaelfranca @byroot