### PR TITLE
Respond to all changes

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -1,6 +1,9 @@
 require "ar_transaction_changes/version"
+require 'attributes_changed_by_write'
 
 module ArTransactionChanges
+  include AttributeChangedByWrite
+
   def _run_create_callbacks
     ret = super
     store_transaction_changed_attributes if ret != false
@@ -26,7 +29,7 @@ module ArTransactionChanges
   end
 
   def transaction_changed_attributes
-    changed_attributes.merge(@transaction_changed_attributes ||= {})
+    attributes_changed_by_setter.merge(attributes_changed_by_write.merge(@transaction_changed_attributes ||= {}))
   end
 
   private

--- a/lib/attributes_changed_by_write.rb
+++ b/lib/attributes_changed_by_write.rb
@@ -1,0 +1,28 @@
+module ArTransactionChanges
+  module AttributeChangedByWrite
+    def attributes_changed_by_write
+      @attributes_changed_by_write ||= ActiveSupport::HashWithIndifferentAccess.new
+    end
+
+    private
+
+    def store_to_attributes_changed_by_write(attr_name)
+      @attributes_changed_by_write = {attr_name.to_s => attributes[attr_name]}.merge(attributes_changed_by_write)
+    end
+
+    def changes_applied
+      @attributes_changed_by_write = ActiveSupport::HashWithIndifferentAccess.new
+      super
+    end
+
+    def clear_changes_information
+      @attributes_changed_by_write = ActiveSupport::HashWithIndifferentAccess.new
+      super
+    end
+
+    def write_attribute(attr_name, value)
+      store_to_attributes_changed_by_write(attr_name) if attributes[attr_name] != value
+      super
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ ActiveRecord::Base.connection.tap do |db|
   db.create_table(:users) do |t|
     t.string :name
     t.string :occupation
+    t.timestamps null: false
   end
 end
 

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -86,4 +86,11 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
 
     assert_equal [old_updated_at, @user.updated_at], @user.stored_transaction_changes["updated_at"]
   end
+
+  def test_transaction_changes_for_multiple_changes
+    @user.name = "Dillon"
+    @user.name = "Lisa"
+    @user.save!
+    assert_equal ["Dylan", "Lisa"], @user.stored_transaction_changes["name"]
+  end
 end

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -66,4 +66,24 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
     assert_equal ["Dylan", "Dillon"], @user.stored_transaction_changes["name"]
   end
 
+  def test_transaction_changes_for_changing_updated_at
+    @user.update_attributes!(updated_at: Time.now - 1.second)
+    old_updated_at = @user.updated_at
+    @user.stored_transaction_changes = nil
+
+    @user.updated_at = Time.now
+    @user.save!
+
+    assert_equal [old_updated_at, @user.updated_at], @user.stored_transaction_changes["updated_at"]
+  end
+
+  def test_transaction_changes_for_touch
+    @user.update_attributes!(updated_at: Time.now - 1.second)
+    old_updated_at = @user.updated_at
+    @user.stored_transaction_changes = nil
+
+    @user.touch
+
+    assert_equal [old_updated_at, @user.updated_at], @user.stored_transaction_changes["updated_at"]
+  end
 end


### PR DESCRIPTION
`changed_attributes` only responds to changes made by setter, missing those made by `write_attribute` directly, which includes changes to `updated_at` made by `touch`.  This adds and uses `all_changed_attributes` which corrects for this.