### PR TITLE
Respond to all changes v2

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -20,8 +20,8 @@ module ArTransactionChanges
   private
 
   def write_attribute(attr_name, value) # override
-    unless transaction_changed_attributes.key?(attr_name)
-      transaction_changed_attributes[attr_name] = attributes[attr_name]
+    unless transaction_changed_attributes.key?(attr_name) || attributes.with_indifferent_access[attr_name] == value
+      transaction_changed_attributes[attr_name] = attributes.with_indifferent_access[attr_name]
     end
     super
   end

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -38,10 +38,12 @@ module ArTransactionChanges
   private
 
   def write_attribute(attr_name, value) # override
-    unless transaction_changed_attributes.key?(attr_name) || attributes.with_indifferent_access[attr_name] == value
-      transaction_changed_attributes[attr_name] = attributes.with_indifferent_access[attr_name]
+    old_value = attributes.with_indifferent_access[attr_name]
+    ret = super
+    unless transaction_changed_attributes.key?(attr_name) || value == old_value
+      transaction_changed_attributes[attr_name] = old_value
     end
-    super
+    ret
   end
 
   def store_deprecated_transaction_changed_attributes

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -38,7 +38,8 @@ module ArTransactionChanges
   private
 
   def write_attribute(attr_name, value) # override
-    old_value = attributes.with_indifferent_access[attr_name]
+    attr_name = attr_name.to_s
+    old_value = attributes[attr_name]
     ret = super
     unless transaction_changed_attributes.key?(attr_name) || value == old_value
       transaction_changed_attributes[attr_name] = old_value

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -1,18 +1,6 @@
 require "ar_transaction_changes/version"
 
 module ArTransactionChanges
-  def _run_create_callbacks
-    ret = super
-    store_transaction_changed_attributes if ret != false
-    ret
-  end
-
-  def _run_update_callbacks
-    ret = super
-    store_transaction_changed_attributes if ret != false
-    ret
-  end
-
   def _run_commit_callbacks
     super
   ensure
@@ -26,12 +14,15 @@ module ArTransactionChanges
   end
 
   def transaction_changed_attributes
-    changed_attributes.merge(@transaction_changed_attributes ||= {})
+    @transaction_changed_attributes ||= HashWithIndifferentAccess.new
   end
 
   private
 
-  def store_transaction_changed_attributes
-    @transaction_changed_attributes = transaction_changed_attributes
+  def write_attribute(attr_name, value) # override
+    unless transaction_changed_attributes.key?(attr_name)
+      transaction_changed_attributes[attr_name] = attributes[attr_name]
+    end
+    super
   end
 end

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -1,16 +1,34 @@
 require "ar_transaction_changes/version"
 
 module ArTransactionChanges
+  def _run_create_callbacks
+    ret = super
+    store_deprecated_transaction_changed_attributes if ret != false
+    ret
+  end
+
+  def _run_update_callbacks
+    ret = super
+    store_deprecated_transaction_changed_attributes if ret != false
+    ret
+  end
+
   def _run_commit_callbacks
     super
   ensure
+    @deprecated_transaction_changed_attributes = nil
     @transaction_changed_attributes = nil
   end
 
   def _run_rollback_callbacks
     super
   ensure
+    @deprecated_transaction_changed_attributes = nil
     @transaction_changed_attributes = nil
+  end
+
+  def deprecated_transaction_changed_attributes
+    changed_attributes.merge(@deprecated_transaction_changed_attributes ||= {})
   end
 
   def transaction_changed_attributes
@@ -25,4 +43,9 @@ module ArTransactionChanges
     end
     super
   end
+
+  def store_deprecated_transaction_changed_attributes
+    @deprecated_transaction_changed_attributes = deprecated_transaction_changed_attributes
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ ActiveRecord::Base.connection.tap do |db|
   db.create_table(:users) do |t|
     t.string :name
     t.string :occupation
+    t.timestamps null: false
   end
 end
 

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -86,4 +86,14 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
 
     assert_equal [old_updated_at, @user.updated_at], @user.stored_transaction_changes["updated_at"]
   end
+
+  def test_transaction_changes_doesnt_record_non_changes
+    @user.transaction do
+      @user.name = "Dylan"
+      @user.save!
+
+      @user.reload
+    end
+    refute @user.stored_transaction_changes["name"]
+  end
 end

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -66,4 +66,24 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
     assert_equal ["Dylan", "Dillon"], @user.stored_transaction_changes["name"]
   end
 
+  def test_transaction_changes_for_changing_updated_at
+    @user.update_attributes!(updated_at: Time.now - 1.second)
+    old_updated_at = @user.updated_at
+    @user.stored_transaction_changes = nil
+
+    @user.updated_at = Time.now
+    @user.save!
+
+    assert_equal [old_updated_at, @user.updated_at], @user.stored_transaction_changes["updated_at"]
+  end
+
+  def test_transaction_changes_for_touch
+    @user.update_attributes!(updated_at: Time.now - 1.second)
+    old_updated_at = @user.updated_at
+    @user.stored_transaction_changes = nil
+
+    @user.touch
+
+    assert_equal [old_updated_at, @user.updated_at], @user.stored_transaction_changes["updated_at"]
+  end
 end


### PR DESCRIPTION
This mimicked the behaviour of `changed_attributes`, which is an alias for the more aptly named `attributes_changed_by_setter` in terms of which changes it tracked. This allowed invisible changes through things like `touch`, which uses `write_attribute`, bypassing the setter method. This changes the behaviour to capture all changes through `write_attribute`, and adds `deprecated_transaction_changed_attributes`, which maintains the old `transaction_changed_attributes` behaviour.