### PR TITLE
changed_attributes is deprecated in rails 5.1

### DIFF
--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.1.0.rc1"
+
+gemspec

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -28,7 +28,11 @@ module ArTransactionChanges
   end
 
   def deprecated_transaction_changed_attributes
-    changed_attributes.merge(@deprecated_transaction_changed_attributes ||= {})
+    if ActiveRecord::VERSION::MAJOR <= 4 || ActiveRecord::VERSION::STRING =~ /^5.0/
+      changed_attributes.merge(@deprecated_transaction_changed_attributes ||= {})
+    else
+      saved_changes.transform_values(&:first)
+    end
   end
 
   def transaction_changed_attributes


### PR DESCRIPTION
Based on the commit here https://github.com/rails/rails/commit/16ae3db5a5c6a08383b974ae6c96faac5b4a3c81

calling saved_changes.transform_values(&:first) is the way to implement the same behaviour as the deprecated changed_attributes method in Rails 5.1