### PR TITLE
Fix compatibility with Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ gemfile:
   - Gemfile.rails42
   - Gemfile.rails50
   - Gemfile.rails51
+  - Gemfile.rails52
 
 matrix:
   include:

--- a/Gemfile.rails52
+++ b/Gemfile.rails52
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.2.0.beta1"
+
+gemspec

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 ENV["RAILS_ENV"] = "test"
 require 'pathname'
 require 'yaml'
-require 'active_record'
 require 'ar_transaction_changes'
 require 'minitest/autorun'
 


### PR DESCRIPTION
On Rails 5.2 (via https://github.com/rails/rails/pull/29495), attribute writer methods call `_write_attribute` instead of `write_attribute` to avoid an unnecessary check for attribute aliases. `write_attribute` is now implemented in terms of `_write_attribute`, so we only need to override that one method.