### PR TITLE
Remove upperbound for Active Record version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
   include:
     - rvm: 2.1.9
       gemfile: Gemfile.rails42
+    - rvm: 2.5.0
+      gemfile: Gemfile.rails-edge
 
 services:
   - mysql

--- a/Gemfile.rails-edge
+++ b/Gemfile.rails-edge
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'rails', github: 'rails'
+
+gemspec

--- a/ar_transaction_changes.gemspec
+++ b/ar_transaction_changes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", ">= 4.2.4", "< 6.0"
+  gem.add_dependency "activerecord", ">= 4.2.4"
 
   gem.add_development_dependency("rake")
   gem.add_development_dependency("mysql2")


### PR DESCRIPTION
Removing the upperbound and testing against Rails edge. This way app
developers don't need to update this gem when a new release is higher
than the current upperbound