### PR TITLE
Update minimum supported Active Record version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ sudo: false
 
 jobs:
   include:
-    - rvm: 2.4
+    - name: "Minimum supported versions"
+      rvm: 2.4
       gemfile: Gemfile.rails52
-    - rvm: 2.7
-      gemfile: Gemfile.rails60
-    - rvm: 2.7
+    - name: "Latest released versions"
+      rvm: 2.7
+      gemfile: Gemfile
+    - name: "Rails master branch"
+      rvm: 2.7
       gemfile: Gemfile.rails_head
 
 services:

--- a/Gemfile.rails60
+++ b/Gemfile.rails60
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem 'activerecord', '~> 6.0.0'
-
-gemspec

--- a/ar_transaction_changes.gemspec
+++ b/ar_transaction_changes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", ">= 4.2.4"
+  gem.add_dependency "activerecord", ">= 5.2.0"
 
   gem.add_development_dependency("rake")
   gem.add_development_dependency("mysql2")

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -18,13 +18,7 @@ module ArTransactionChanges
     @transaction_changed_attributes ||= HashWithIndifferentAccess.new
   end
 
-  method_name = if ActiveRecord.gem_version >= Gem::Version.new("5.2.0.beta1")
-    "_write_attribute"
-  else
-    "write_attribute"
-  end
-
-  define_method(method_name) do |attr_name, value|
+  def _write_attribute(attr_name, value)
     attr_name = attr_name.to_s
     old_value = read_attribute(attr_name)
     ret = super(attr_name, value)


### PR DESCRIPTION
cc @gmcgibbon 

Looks like we forgot to update the minimum rails dependency in https://github.com/dylanahsmith/ar_transaction_changes/pull/24.  I've also removed the version check that is no longer needed.

I've also named the travis CI jobs to make their purpose clearer.  It also didn't make sense to lock the version of rails when testing against the latest released version, so I just re-used `Gemfile` for this purpose, since it already doesn't constrain the rails version.