### PR TITLE
Add read_attribute to type_cast value.

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -22,7 +22,8 @@ module ArTransactionChanges
     attr_name = attr_name.to_s
     old_value = read_attribute(attr_name)
     ret = super(attr_name, value)
-    unless transaction_changed_attributes.key?(attr_name) || value == old_value
+    new_value = read_attribute(attr_name)
+    unless transaction_changed_attributes.key?(attr_name) || new_value == old_value
       transaction_changed_attributes[attr_name] = old_value
     end
     ret

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ ActiveRecord::Base.connection.tap do |db|
   db.create_table(:users) do |t|
     t.string :name
     t.string :occupation
+    t.integer :age
     t.timestamps null: false
   end
 end

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TransactionChangesTest < MiniTest::Unit::TestCase
   def setup
-    @user = User.new(:name => "Dylan", :occupation => "Developer")
+    @user = User.new(:name => "Dylan", :occupation => "Developer", age: 20)
     @user.save!
     @user.stored_transaction_changes = nil
   end
@@ -93,5 +93,14 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
       @user.save!
     end
     refute @user.stored_transaction_changes["name"]
+  end
+
+  def test_transaction_changes_type_cast
+    # "20" will be converted to 20 by read_attribute https://apidock.com/rails/ActiveRecord/AttributeMethods/read_attribute
+    @user.transaction do
+      @user.age = "20"
+      @user.save!
+    end
+    assert_empty @user.stored_transaction_changes
   end
 end


### PR DESCRIPTION
Hello

We've encountered a type cast issue with the gem.

AR [read_attribute](url) is type casting the value but it wasnt considered when comparing old_value with new_value.

 