### PR TITLE
`write_attribute` no longer delegates to `_write_attribute:

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -19,9 +19,25 @@ module ArTransactionChanges
   end
 
   def _write_attribute(attr_name, value)
+    _store_transaction_changed_attributes(attr_name) do
+      super(attr_name, value)
+    end
+  end
+
+  if ActiveRecord.version >= Gem::Version.new('6.1.0.alpha')
+    def write_attribute(attr_name, value)
+      _store_transaction_changed_attributes(attr_name) do
+        super(attr_name, value)
+      end
+    end
+  end
+
+  private
+
+  def _store_transaction_changed_attributes(attr_name)
     attr_name = attr_name.to_s
     old_value = read_attribute(attr_name)
-    ret = super(attr_name, value)
+    ret = yield
     new_value = read_attribute(attr_name)
     unless transaction_changed_attributes.key?(attr_name) || new_value == old_value
       transaction_changed_attributes[attr_name] = old_value

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -23,6 +23,13 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
     assert_equal ["Dylan", "Dillon"], @user.stored_transaction_changes["name"]
   end
 
+  def test_transaction_changes_for_updating_attribute
+    @user[:name] = "Dillon"
+    @user.save!
+
+    assert_equal ["Dylan", "Dillon"], @user.stored_transaction_changes["name"]
+  end
+
   def test_transaction_changes_for_double_save
     @user.transaction do
       @user.name = "Dillon"


### PR DESCRIPTION
`write_attribute` no longer delegates to `_write_attribute:

- Since rails/rails@27a1ca2bfeda4298bbf44da17d07fac4147a4b1c,
  doing `model[:attr_name] = ...` will no longer go through
  `_write_attribute`

cc/ @dylanahsmith @casperisfine @etiennebarrie @rafaelfranca