### PR TITLE
Avoid to read serialized attributes as it clones the value

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -53,6 +53,9 @@ module ArTransactionChanges
 
   def _read_attribute_for_transaction(attr_name)
     attribute = @attributes[attr_name]
+    # Avoid causing an earlier memoized type cast of mutable serialized user values,
+    # since could prevent mutations of that user value from affecting the attribute value
+    # that would affect it without using this library.
     if attribute.type.is_a?(::ActiveRecord::Type::Serialized)
       if attribute.came_from_user?
         attribute.type.serialize(attribute.value_before_type_cast)

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -36,12 +36,31 @@ module ArTransactionChanges
 
   def _store_transaction_changed_attributes(attr_name)
     attr_name = attr_name.to_s
-    old_value = read_attribute(attr_name)
+    old_value = _read_attribute_for_transaction(attr_name)
     ret = yield
-    new_value = read_attribute(attr_name)
+    new_value = _read_attribute_for_transaction(attr_name)
     unless transaction_changed_attributes.key?(attr_name) || new_value == old_value
-      transaction_changed_attributes[attr_name] = old_value
+      attribute = @attributes[attr_name]
+      transaction_changed_attributes[attr_name] = if attribute.type.is_a?(::ActiveRecord::Type::Serialized)
+        attribute.type.deserialize(old_value)
+      else
+        old_value
+      end
+      transaction_changed_attributes
     end
     ret
+  end
+
+  def _read_attribute_for_transaction(attr_name)
+    attribute = @attributes[attr_name]
+    if attribute.type.is_a?(::ActiveRecord::Type::Serialized)
+      if attribute.came_from_user?
+        attribute.type.serialize(attribute.value_before_type_cast)
+      else
+        attribute.value_before_type_cast
+      end
+    else
+      _read_attribute(attr_name)
+    end
   end
 end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,6 +1,16 @@
 class User < ActiveRecord::Base
   include ArTransactionChanges
 
+  class ConnectionDetails
+    attr_accessor :client_ip
+
+    def initialize(client_ip:)
+      @client_ip = client_ip
+    end
+  end
+
+  serialize :connection_details, Array
+
   attr_accessor :stored_transaction_changes
 
   after_commit :store_transaction_changes_for_tests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ ActiveRecord::Base.connection.tap do |db|
     t.string :name
     t.string :occupation
     t.integer :age
+    t.text :connection_details
     t.timestamps null: false
   end
 end

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -110,4 +110,18 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
     end
     assert_empty @user.stored_transaction_changes
   end
+
+  def test_serialized_attributes_value
+    @user.connection_details = [User::ConnectionDetails.new(client_ip: '1.1.1.1')]
+    @user.save!
+    assert_instance_of Array, @user.stored_transaction_changes['connection_details']
+  end
+
+  def test_serialized_attributes_mutation
+    details = User::ConnectionDetails.new(client_ip: '1.1.1.1')
+    @user.connection_details = [details]
+    details.client_ip = '2.2.2.2'
+    @user.save!
+    assert_equal '2.2.2.2', @user.connection_details.first.client_ip
+  end
 end

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -114,7 +114,9 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
   def test_serialized_attributes_value
     @user.connection_details = [User::ConnectionDetails.new(client_ip: '1.1.1.1')]
     @user.save!
-    assert_instance_of Array, @user.stored_transaction_changes['connection_details']
+    old_value, new_value = @user.stored_transaction_changes['connection_details']
+    assert_equal([], old_value)
+    assert_equal(['1.1.1.1'], new_value.map(&:client_ip))
   end
 
   def test_serialized_attributes_mutation


### PR DESCRIPTION
`read_attribute` goes through `Attribute#cast` which ultimately for serialized attributes goes through `deserialize(serialize(value))` which is akin to cloning the attribute value.

The problem with this is that doing so you might lose all current mutations to the serialized value.

I'm not super fan of the implementation, so if you have a better idea how to handle this I'm all ears.

@dylanahsmith @Edouard-chin @rafaelfranca @etiennebarrie