### PR TITLE
Prevent storing attributes that are changed multiple times and back to its original value

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -41,7 +41,7 @@ module ArTransactionChanges
     old_value = _read_attribute_for_transaction(attr_name)
     ret = yield
     new_value = _read_attribute_for_transaction(attr_name)
-    unless transaction_changed_attributes.key?(attr_name) || new_value == old_value
+    if !transaction_changed_attributes.key?(attr_name) && new_value != old_value
       attribute = @attributes[attr_name]
       transaction_changed_attributes[attr_name] = if attribute.type.is_a?(::ActiveRecord::Type::Serialized)
         attribute.type.deserialize(old_value)
@@ -49,6 +49,17 @@ module ArTransactionChanges
         old_value
       end
       transaction_changed_attributes
+    elsif transaction_changed_attributes.key?(attr_name)
+      attribute = @attributes[attr_name]
+      if attribute.type.is_a?(::ActiveRecord::Type::Serialized)
+        new_value = attribute.type.deserialize(new_value)
+      end
+
+      stored_value = transaction_changed_attributes[attr_name]
+
+      if new_value == stored_value
+        transaction_changed_attributes.delete(attr_name)
+      end
     end
     ret
   end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -10,10 +10,17 @@ class User < ActiveRecord::Base
   end
 
   serialize :connection_details, Array
+  serialize :favourite_foods, Array
+  serialize :favourite_cities_by_country, Hash
 
   attr_accessor :stored_transaction_changes
 
+  before_save :sort_favourite_foods
   after_commit :store_transaction_changes_for_tests
+
+  def sort_favourite_foods
+    self.favourite_foods = favourite_foods.sort if favourite_foods_changed?
+  end
 
   def store_transaction_changes_for_tests
     @stored_transaction_changes = transaction_changed_attributes.reduce({}) do |changes, (attr_name, value)|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,8 @@ ActiveRecord::Base.connection.tap do |db|
     t.string :occupation
     t.integer :age
     t.text :connection_details
+    t.text :favourite_foods
+    t.text :favourite_cities_by_country
     t.timestamps null: false
   end
 end


### PR DESCRIPTION
This is related to an old bug in #12 

We faced this issue where we have a `before_save` hook that sorts a serialized attribute.

This should check if a change is already stored and remove the attribute if it's back to its original value.

@emilienoel
@coreymartella