### PR TITLE
Include forced changes in transactional changes

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -34,6 +34,11 @@ module ArTransactionChanges
     end
   end
 
+  def attribute_will_change!(attr_name)
+    transaction_changed_attributes[attr_name] = _read_attribute_for_transaction(attr_name)
+    super
+  end
+
   private
 
   def _store_transaction_changed_attributes(attr_name)

--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -35,11 +35,21 @@ module ArTransactionChanges
   end
 
   def attribute_will_change!(attr_name)
-    transaction_changed_attributes[attr_name] = _read_attribute_for_transaction(attr_name)
+    unless transaction_changed_attributes.key?(attr_name)
+      value = _read_attribute_for_transaction(attr_name)
+      value = _deserialize_transaction_change_value(attr_name, value)
+      transaction_changed_attributes[attr_name] = value
+    end
     super
   end
 
   private
+
+  def _deserialize_transaction_change_value(attr_name, value)
+    attribute = @attributes[attr_name]
+    return value unless attribute.type.is_a?(::ActiveRecord::Type::Serialized)
+    attribute.type.deserialize(value)
+  end
 
   def _store_transaction_changed_attributes(attr_name)
     attr_name = attr_name.to_s
@@ -47,17 +57,9 @@ module ArTransactionChanges
     ret = yield
     new_value = _read_attribute_for_transaction(attr_name)
     if !transaction_changed_attributes.key?(attr_name) && new_value != old_value
-      attribute = @attributes[attr_name]
-      transaction_changed_attributes[attr_name] = if attribute.type.is_a?(::ActiveRecord::Type::Serialized)
-        attribute.type.deserialize(old_value)
-      else
-        old_value
-      end
+      transaction_changed_attributes[attr_name] = _deserialize_transaction_change_value(attr_name, old_value)
     elsif transaction_changed_attributes.key?(attr_name)
-      attribute = @attributes[attr_name]
-      if attribute.type.is_a?(::ActiveRecord::Type::Serialized)
-        new_value = attribute.type.deserialize(new_value)
-      end
+      new_value = _deserialize_transaction_change_value(attr_name, new_value)
 
       stored_value = transaction_changed_attributes[attr_name]
 

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -153,4 +153,12 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
 
     assert_empty @user.stored_transaction_changes
   end
+
+  def test_mutating_serialized_attribute_in_place_with_attribute_will_change
+    @user.notes_will_change!
+    @user.notes.push('a')
+    @user.save!
+
+    assert_equal [nil, ['a']], @user.stored_transaction_changes['notes']
+  end
 end

--- a/test/transaction_changes_test.rb
+++ b/test/transaction_changes_test.rb
@@ -159,6 +159,19 @@ class TransactionChangesTest < MiniTest::Unit::TestCase
     @user.notes.push('a')
     @user.save!
 
-    assert_equal [nil, ['a']], @user.stored_transaction_changes['notes']
+    assert_equal [[], ['a']], @user.stored_transaction_changes['notes']
+  end
+
+  def test_double_modification_with_attribute_will_change
+    @user.transaction do
+      @user.notes = ['a']
+      @user.save!
+
+      @user.notes_will_change!
+      @user.notes.push('b')
+      @user.save!
+    end
+
+    assert_equal [[], ['a', 'b']], @user.stored_transaction_changes['notes']
   end
 end


### PR DESCRIPTION
When the `attribute_will_change!` method is called, the attribute will be considered changed and written to the database during the next save, regardless of its value.

`transaction_changed_attributes` should also reflect this behaviour, so that caches are cleared when a serialised attribute is mutated in place.