### PR TITLE
Improve Shapes Friendliness

### DIFF
--- a/lib/ar_transaction_changes.rb
+++ b/lib/ar_transaction_changes.rb
@@ -45,6 +45,11 @@ module ArTransactionChanges
 
   private
 
+  def init_internals
+    super
+    @transaction_changed_attributes = nil
+  end
+
   def _deserialize_transaction_change_value(attr_name, value)
     attribute = @attributes[attr_name]
     return value unless attribute.type.is_a?(::ActiveRecord::Type::Serialized)


### PR DESCRIPTION
For optimal performance in Ruby 3.2+ it's preferable to define instance variables in a consistent order